### PR TITLE
remove disquss in default.html

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -166,9 +166,5 @@ ga('send', 'pageview');
 
 <script src="{{ site.baseurl }}/assets/js/ie10-viewport-bug-workaround.js"></script>
 
-{% if page.layout == 'post' %}
-<script id="dsq-count-scr" src="//{{site.disqus}}.disqus.com/count.js"></script>
-{% endif %}
-
 </body>
 </html>


### PR DESCRIPTION
removing disquss comments so they don't show up even when not setting comments: false in a _post